### PR TITLE
Increase lftp timeout from 3 to 180 seconds

### DIFF
--- a/src/python/lftp/lftp.py
+++ b/src/python/lftp/lftp.py
@@ -55,7 +55,7 @@ class Lftp:
         self.logger = logging.getLogger("Lftp")
         self.__expect_pattern = "lftp {}@{}:.*>".format(self.__user, self.__address)
         self.__job_status_parser = LftpJobStatusParser()
-        self.__timeout = 3  # in seconds
+        self.__timeout = 180  # in seconds
         self.__consecutive_status_errors = 0
 
         self.__log_command_output = False


### PR DESCRIPTION
The previous 3-second timeout was too short and could cause premature
timeouts during lftp operations.