### PR TITLE
Fix Poetry package-mode configuration

### DIFF
--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -25,3 +25,6 @@ pyinstaller = "*"
 testfixtures = "*"
 webtest = "*"
 pytest = "^7.0.0"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]


### PR DESCRIPTION
Add package-mode = false to pyproject.toml to fix the error
"No file/folder found for package seedsync". This disables
Poetry's packaging mode since the project uses Poetry only
for dependency management, not as a distributable package.