### PR TITLE
Make docker-image Dockerfile self-contained

### DIFF
--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -1,5 +1,69 @@
-ARG STAGING_REGISTRY=localhost:5000
-ARG STAGING_VERSION=latest
+# ============================================================================
+# Angular Build Stages
+# ============================================================================
+
+# Creates environment for angular
+FROM node:12.16 as seedsync_build_angular_env
+COPY src/angular/package*.json /app/
+WORKDIR /app
+RUN npm install
+
+# Builds angular app into html
+# Output is in /build/dist/
+FROM seedsync_build_angular_env as seedsync_build_angular
+COPY src/angular /app
+WORKDIR /app
+RUN node_modules/@angular/cli/bin/ng build -prod --output-path /build/dist/
+
+# ============================================================================
+# Scanfs Build Stages
+# ============================================================================
+
+# Creates environment to build python binaries
+FROM ubuntu:16.04 as seedsync_build_pyinstaller_env
+RUN apt-get update && apt-get install -y software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && apt-get install -y \
+    python3.8 \
+    python3.8-dev \
+    python3.8-distutils \
+    curl \
+    binutils
+# Switch to Python 3.8
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
+RUN update-alternatives --set python /usr/bin/python3.8
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+RUN update-alternatives --set python3 /usr/bin/python3.8
+# Install Poetry
+RUN curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py --force-reinstall && \
+    rm get-pip.py
+RUN pip3 install poetry
+RUN poetry config virtualenvs.create false
+COPY src/python/pyproject.toml /app/python/
+COPY src/python/poetry.lock /app/python/
+WORKDIR /python
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+RUN cd /app/python && poetry install
+
+# Builds scanfs with pyinstaller
+# Output is in /build/dist/
+FROM seedsync_build_pyinstaller_env as seedsync_build_scanfs
+COPY src/python /python
+RUN mkdir -p /build
+RUN	pyinstaller /python/scan_fs.py \
+    -y \
+    --onefile \
+    -p /python \
+    --distpath /build/dist \
+    --workpath /build/work \
+    --specpath /build \
+    --name scanfs
+
+# ============================================================================
+# Python Runtime Environment
+# ============================================================================
 
 # Creates environment to run Seedsync python code
 # Installs all python dependencies
@@ -51,11 +115,9 @@ COPY src/python /app/python
 
 
 # Full Seedsync docker image
-FROM ${STAGING_REGISTRY}/seedsync/build/angular/export:${STAGING_VERSION} as seedsync_build_angular_export
-FROM ${STAGING_REGISTRY}/seedsync/build/scanfs/export:${STAGING_VERSION} as seedsync_build_scanfs_export
 FROM seedsync_run_python as seedsync_run
-COPY --from=seedsync_build_angular_export /html /app/html
-COPY --from=seedsync_build_scanfs_export /scanfs /app/scanfs
+COPY --from=seedsync_build_angular /build/dist /app/html
+COPY --from=seedsync_build_scanfs /build/dist/scanfs /app/scanfs
 COPY src/docker/build/docker-image/setup_default_config.sh /scripts/
 
 # Disable the known hosts prompt


### PR DESCRIPTION
Remove external staging registry dependencies by building Angular and scanfs locally within the same Dockerfile. This eliminates the need for the STAGING_REGISTRY and STAGING_VERSION build arguments.