### PR TITLE
Fix Docker Angular build by creating /build directory

### DIFF
--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -13,6 +13,7 @@ RUN npm install
 FROM seedsync_build_angular_env as seedsync_build_angular
 COPY src/angular /app
 WORKDIR /app
+RUN mkdir -p /build
 RUN node_modules/@angular/cli/bin/ng build -prod --output-path /build/dist/
 
 # ============================================================================


### PR DESCRIPTION
The ng build command was failing with ENOENT because the /build directory didn't exist. Added mkdir -p /build before the build command, matching the pattern already used in the seedsync_build_scanfs stage.