### PR TITLE
Add skipLibCheck to fix @types/eventsource conflict

### DIFF
--- a/src/angular/tsconfig.json
+++ b/src/angular/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "skipLibCheck": true,
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,


### PR DESCRIPTION
The old @types/eventsource package has type declarations that conflict with DOM types, causing TypeScript compilation errors. Adding skipLibCheck skips type checking of declaration files, resolving the conflict while still type-checking the application code.