### PR TITLE
Fix npm install for Node 20 with legacy Angular 4.x

### DIFF
--- a/src/docker/build/deb/Dockerfile
+++ b/src/docker/build/deb/Dockerfile
@@ -62,10 +62,11 @@ RUN	pyinstaller /python/scan_fs.py \
 
 # Creates environment for angular
 # Note: Using Node 20 LTS. Angular 4.x is legacy but npm/build still works.
+# --legacy-peer-deps required for old Angular 4.x peer dependency conflicts
 FROM node:20-slim as seedsync_build_angular_env
 COPY src/angular/package*.json /app/
 WORKDIR /app
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 # Builds angular app into html
 # Output is in /build/dist/

--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -4,10 +4,11 @@
 
 # Creates environment for angular
 # Note: Using Node 20 LTS. Angular 4.x is legacy but npm/build still works.
+# --legacy-peer-deps required for old Angular 4.x peer dependency conflicts
 FROM node:20-slim as seedsync_build_angular_env
 COPY src/angular/package*.json /app/
 WORKDIR /app
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 # Builds angular app into html
 # Output is in /build/dist/


### PR DESCRIPTION
Add --legacy-peer-deps flag to handle peer dependency conflicts that are now strictly enforced in npm 7+ (Node 20 ships with npm 10).