### PR TITLE
Fix node-sass version for Node 20 compatibility

### DIFF
--- a/src/angular/package.json
+++ b/src/angular/package.json
@@ -52,7 +52,7 @@
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-mocha-reporter": "^2.2.5",
-    "sass": "^1.69.0",
+    "node-sass": "^9.0.0",
     "protractor": "~5.1.2",
     "ts-node": "~3.2.0",
     "tslint": "~5.3.2",


### PR DESCRIPTION
Angular CLI 1.3.2 webpack config expects node-sass, not Dart Sass. Use node-sass 9.0.0 which supports Node 20 (was 4.5.3 for Node 12).