### PR TITLE
Fix GLIBC compatibility by using Ubuntu 20.04 for PyInstaller build

### DIFF
--- a/src/docker/build/deb/Dockerfile
+++ b/src/docker/build/deb/Dockerfile
@@ -1,5 +1,7 @@
 # Creates environment to build python binaries
-FROM ubuntu:22.04 as seedsync_build_pyinstaller_env
+# Using Ubuntu 20.04 (GLIBC 2.31) for broader compatibility with older systems
+# Ubuntu 22.04 uses GLIBC 2.35 which causes runtime errors on older distros
+FROM ubuntu:20.04 as seedsync_build_pyinstaller_env
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa && \


### PR DESCRIPTION
The scanfs binary was failing with "GLIBC_2.35 not found" error when running on systems with older glibc versions. This is because Ubuntu 22.04 uses GLIBC 2.35, and PyInstaller links against this version.

Changed the build environment from Ubuntu 20.04 (GLIBC 2.31) to ensure broader compatibility with older Linux distributions. The deadsnakes PPA still provides Python 3.11 on Ubuntu 20.04.