### PR TITLE
Fix GLIBC compatibility in docker-image Dockerfile

### DIFF
--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -23,7 +23,9 @@ RUN node_modules/@angular/cli/bin/ng build -prod --output-path /build/dist/
 # ============================================================================
 
 # Creates environment to build python binaries
-FROM ubuntu:22.04 as seedsync_build_pyinstaller_env
+# Using Ubuntu 20.04 (GLIBC 2.31) for broader compatibility with older systems
+# Ubuntu 22.04 uses GLIBC 2.35 which causes runtime errors on older distros
+FROM ubuntu:20.04 as seedsync_build_pyinstaller_env
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa && \


### PR DESCRIPTION
Apply the same fix as deb/Dockerfile: use Ubuntu 20.04 instead of 22.04 for the PyInstaller build environment to avoid GLIBC_2.35 dependency.