### PR TITLE
Switch to python:3.11-slim-bullseye for PyInstaller builds

### DIFF
--- a/src/docker/build/deb/Dockerfile
+++ b/src/docker/build/deb/Dockerfile
@@ -1,9 +1,11 @@
 # Creates environment to build python binaries
-# Using manylinux_2_28 (AlmaLinux 8, GLIBC 2.28) for broad compatibility
-# This ensures the built binaries work on most Linux distributions
-FROM quay.io/pypa/manylinux_2_28_x86_64 as seedsync_build_pyinstaller_env
-# Use Python 3.11 from the manylinux image
-ENV PATH="/opt/python/cp311-cp311/bin:$PATH"
+# Using Debian 11 (bullseye) with GLIBC 2.31 for compatibility with older systems
+# Ubuntu 22.04 uses GLIBC 2.35 which causes runtime errors on older distros
+FROM python:3.11-slim-bullseye as seedsync_build_pyinstaller_env
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    binutils \
+    && rm -rf /var/lib/apt/lists/*
 # Install Poetry
 RUN pip3 install poetry && \
     poetry config virtualenvs.create false

--- a/src/docker/build/docker-image/Dockerfile
+++ b/src/docker/build/docker-image/Dockerfile
@@ -23,11 +23,13 @@ RUN node_modules/@angular/cli/bin/ng build -prod --output-path /build/dist/
 # ============================================================================
 
 # Creates environment to build python binaries
-# Using manylinux_2_28 (AlmaLinux 8, GLIBC 2.28) for broad compatibility
-# This ensures the scanfs binary works on most Linux distributions
-FROM quay.io/pypa/manylinux_2_28_x86_64 as seedsync_build_pyinstaller_env
-# Use Python 3.11 from the manylinux image
-ENV PATH="/opt/python/cp311-cp311/bin:$PATH"
+# Using Debian 11 (bullseye) with GLIBC 2.31 for compatibility with older systems
+# Ubuntu 22.04 uses GLIBC 2.35 which causes runtime errors on older distros
+FROM python:3.11-slim-bullseye as seedsync_build_pyinstaller_env
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    binutils \
+    && rm -rf /var/lib/apt/lists/*
 # Install Poetry
 RUN pip3 install poetry && \
     poetry config virtualenvs.create false


### PR DESCRIPTION
The manylinux_2_28 image has Python built without shared libraries, which PyInstaller requires. Switch to python:3.11-slim-bullseye which:

- Has Python 3.11 with shared libraries (required by PyInstaller)
- Uses Debian 11 with GLIBC 2.31 (older than Ubuntu 22.04's 2.35)
- Provides compatibility with most modern Linux distributions

This fixes both the GLIBC compatibility issue and the PyInstaller shared library requirement.