### PR TITLE
Fix Angular CI tests: keep --remote-debugging-port and add stability …

### DIFF
--- a/src/angular/karma.conf.js
+++ b/src/angular/karma.conf.js
@@ -27,10 +27,16 @@ module.exports = function (config) {
         reporters: ['mocha', 'kjhtml'],
         port: 9876,
         colors: true,
-        logLevel: config.LOG_INFO,
+        logLevel: config.LOG_DEBUG,
         autoWatch: true,
         browsers: ['Chrome'],
         singleRun: false,
+
+        // Timeout settings for CI/Docker environments
+        browserDisconnectTimeout: 10000,
+        browserDisconnectTolerance: 3,
+        browserNoActivityTimeout: 60000,
+        captureTimeout: 60000,
 
         customLaunchers: {
             ChromeHeadless: {
@@ -40,7 +46,16 @@ module.exports = function (config) {
                     '--disable-gpu',
                     '--remote-debugging-port=9222',
                     '--no-sandbox',
-                    '--disable-dev-shm-usage'
+                    '--disable-dev-shm-usage',
+                    '--disable-software-rasterizer',
+                    '--disable-extensions',
+                    '--disable-background-networking',
+                    '--disable-default-apps',
+                    '--disable-sync',
+                    '--disable-translate',
+                    '--mute-audio',
+                    '--hide-scrollbars',
+                    '--metrics-recording-only'
                 ]
             }
         },

--- a/src/docker/test/angular/Dockerfile
+++ b/src/docker/test/angular/Dockerfile
@@ -1,11 +1,20 @@
 FROM seedsync/build/angular/env AS seedsync_test_angular
 
-# Install Chrome for headless testing
-# node:20-slim doesn't include wget, so we need to install it first
+# Install Chrome for headless testing via Google's apt repository
+# This ensures all dependencies are properly resolved
 RUN apt-get update && \
-    apt-get install -y wget gnupg && \
-    wget -nv -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-    dpkg -i /tmp/chrome.deb || apt-get -fy install
+    apt-get install -y wget gnupg ca-certificates && \
+    wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get update && \
+    apt-get install -y google-chrome-stable && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set Chrome binary path for Karma
+ENV CHROME_BIN=/usr/bin/google-chrome-stable
+
+# Node.js 20 compatibility for Angular CLI 1.3.2 (uses older OpenSSL APIs)
+ENV NODE_OPTIONS=--openssl-legacy-provider
 
 COPY \
     src/angular/tsconfig.json \


### PR DESCRIPTION
…fixes

The Chrome headless mode requires --remote-debugging-port=9222 to keep the browser running and connected to Karma. Without this flag, Chrome loads the page and immediately exits with code 0.

Changes:
- Keep --remote-debugging-port=9222 (critical for Karma-Chrome connection)
- Add timeout settings for CI/Docker environments
- Add Chrome stability flags for headless mode
- Install Chrome via apt repository (more reliable)
- Set CHROME_BIN environment variable
- Add NODE_OPTIONS=--openssl-legacy-provider for Node.js 20 compatibility