### PR TITLE
Add ChromeHeadlessCI custom launcher for CI environment compatibility

### DIFF
--- a/src/angular/karma.conf.js
+++ b/src/angular/karma.conf.js
@@ -42,6 +42,16 @@ module.exports = function (config) {
                     '--no-sandbox',
                     '--disable-dev-shm-usage'
                 ]
+            },
+            ChromeHeadlessCI: {
+                base: 'Chrome',
+                flags: [
+                    '--headless=new',
+                    '--disable-gpu',
+                    '--remote-debugging-port=9222',
+                    '--no-sandbox',
+                    '--disable-dev-shm-usage'
+                ]
             }
         }
     });


### PR DESCRIPTION
The Angular tests were failing in CI with the error "Cannot load browser ChromeHeadlessCI: it is not registered!". This adds ChromeHeadlessCI as an alias with the same headless Chrome flags to ensure compatibility with CI environments that may request this browser name.

https://claude.ai/code/session_01KWsMVpkk7Njx1aTQFVeqyA