### PR TITLE
Replace deprecated release actions with GitHub CLI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -249,24 +249,11 @@ jobs:
         run: |
           echo "DEB_PATH=$(readlink -f ./build/*.deb)" >> $GITHUB_ENV
           echo "DEB_NAME=$(basename $(readlink -f ./build/*.deb))" >> $GITHUB_ENV
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Create Release and Upload Asset
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: ${{ github.event.head_commit.message }}
-          draft: false
-          prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ env.DEB_PATH }}
-          asset_name: ${{ env.DEB_NAME }}
-          asset_content_type: application/x-deb
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "Release ${{ github.ref_name }}" \
+            --generate-notes \
+            "${{ env.DEB_PATH }}#${{ env.DEB_NAME }}"


### PR DESCRIPTION
Replace actions/create-release@v1 and actions/upload-release-asset@v1
with gh release create command. These actions are no longer maintained
and cause Node.js 12 deprecation warnings in GitHub Actions.

Fixes #39

https://claude.ai/code/session_01JErpqdGn2xX8HNeKYbAvrG