### PR TITLE
Upgrade Angular from v7.2.16 to v8.2.14 (Chunk 8.4)

### DIFF
--- a/src/angular/package.json
+++ b/src/angular/package.json
@@ -12,14 +12,14 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^7.2.16",
-    "@angular/common": "^7.2.16",
-    "@angular/compiler": "^7.2.16",
-    "@angular/core": "^7.2.16",
-    "@angular/forms": "^7.2.16",
-    "@angular/platform-browser": "^7.2.16",
-    "@angular/platform-browser-dynamic": "^7.2.16",
-    "@angular/router": "^7.2.16",
+    "@angular/animations": "^8.2.14",
+    "@angular/common": "^8.2.14",
+    "@angular/compiler": "^8.2.14",
+    "@angular/core": "^8.2.14",
+    "@angular/forms": "^8.2.14",
+    "@angular/platform-browser": "^8.2.14",
+    "@angular/platform-browser-dynamic": "^8.2.14",
+    "@angular/router": "^8.2.14",
     "angular-webstorage-service": "^1.0.2",
     "bootstrap": "^4.2.1",
     "compare-versions": "^3.4.0",
@@ -32,13 +32,13 @@
     "popper.js": "^1.14.6",
     "rxjs": "^6.6.7",
     "rxjs-compat": "^6.6.7",
-    "zone.js": "^0.8.26"
+    "zone.js": "~0.9.1"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.13.9",
-    "@angular/cli": "~7.3.10",
-    "@angular/compiler-cli": "^7.2.16",
-    "@angular/language-service": "^7.2.16",
+    "@angular-devkit/build-angular": "~0.803.29",
+    "@angular/cli": "~8.3.29",
+    "@angular/compiler-cli": "^8.2.14",
+    "@angular/language-service": "^8.2.14",
     "@playwright/test": "^1.48.0",
     "@types/jasmine": "~3.3.16",
     "@types/jasminewd2": "~2.0.8",
@@ -58,6 +58,6 @@
     "sass": "^1.32.0",
     "playwright": "^1.48.0",
     "ts-node": "~3.2.0",
-    "typescript": "~3.2.4"
+    "typescript": "~3.4.5"
   }
 }

--- a/src/angular/src/app/pages/files/file.component.ts
+++ b/src/angular/src/app/pages/files/file.component.ts
@@ -28,7 +28,7 @@ export class FileComponent implements OnChanges {
     min = Math.min;
 
     // Entire div element
-    @ViewChild("fileElement") fileElement: any;
+    @ViewChild("fileElement", {static: false}) fileElement: any;
 
     @Input() file: ViewFile;
     @Input() options: ViewFileOptions;

--- a/src/angular/src/app/pages/logs/logs-page.component.ts
+++ b/src/angular/src/app/pages/logs/logs-page.component.ts
@@ -25,14 +25,14 @@ export class LogsPageComponent implements OnInit, AfterContentChecked {
 
     public headerHeight: Observable<number>;
 
-    @ViewChild("templateRecord") templateRecord;
-    @ViewChild("templateConnected") templateConnected;
+    @ViewChild("templateRecord", {static: false}) templateRecord;
+    @ViewChild("templateConnected", {static: false}) templateConnected;
 
     // Where to insert the cloned content
-    @ViewChild("container", {read: ViewContainerRef}) container;
+    @ViewChild("container", {static: false, read: ViewContainerRef}) container;
 
-    @ViewChild("logHead") logHead;
-    @ViewChild("logTail") logTail;
+    @ViewChild("logHead", {static: false}) logHead;
+    @ViewChild("logTail", {static: false}) logTail;
 
     public showScrollToTopButton = false;
     public showScrollToBottomButton = false;

--- a/src/angular/src/app/pages/main/app.component.ts
+++ b/src/angular/src/app/pages/main/app.component.ts
@@ -11,7 +11,7 @@ import {DomService} from "../../services/utils/dom.service";
     styleUrls: ["./app.component.scss"]
 })
 export class AppComponent implements OnInit, AfterViewInit {
-    @ViewChild("topHeader") topHeader: ElementRef;
+    @ViewChild("topHeader", {static: false}) topHeader: ElementRef;
 
     showSidebar = false;
     activeRoute: RouteInfo;


### PR DESCRIPTION
Package Updates:
- @angular/* packages: 7.2.16 → 8.2.14
- @angular/cli: 7.3.10 → 8.3.29
- @angular-devkit/build-angular: 0.13.9 → 0.803.29
- typescript: 3.2.4 → 3.4.5
- zone.js: 0.8.26 → 0.9.1

Code Fixes:
- Add static: false flag to all @ViewChild decorators (required by Angular 8)
  - logs-page.component.ts: 5 ViewChild decorators
  - file.component.ts: 1 ViewChild decorator
  - app.component.ts: 1 ViewChild decorator

Build Status:
- npm run build works
- npm run build --prod works

Known Issues (Carry Forward):
- rxjs-compat still required - legacy deep imports in codebase
- npm install requires --legacy-peer-deps - ngx-modialog peer dep conflict
- Dart Sass deprecation warnings - @import and slash division syntax

https://claude.ai/code/session_019nuzjmWjTRpa2SpBtKpjsY