### PR TITLE
Fix npm peer dependency conflicts to allow install without --legacy-p…

### DIFF
--- a/src/angular/package.json
+++ b/src/angular/package.json
@@ -22,10 +22,9 @@
     "@angular/router": "^19.2.18",
     "bootstrap": "^4.2.1",
     "compare-versions": "^3.4.0",
-    "core-js": "^2.4.1",
     "css-element-queries": "^1.1.1",
     "font-awesome": "^4.7.0",
-    "immutable": "^3.8.2",
+    "immutable": "^4.3.0",
     "jquery": "^3.7.1",
     "popper.js": "^1.14.6",
     "rxjs": "^7.5.0",
@@ -58,5 +57,10 @@
     "playwright": "^1.48.0",
     "ts-node": "~10.9.0",
     "typescript": "~5.7.3"
+  },
+  "overrides": {
+    "karma-jasmine": {
+      "jasmine-core": "$jasmine-core"
+    }
   }
 }

--- a/src/angular/src/app/services/settings/config.service.ts
+++ b/src/angular/src/app/services/settings/config.service.ts
@@ -49,7 +49,8 @@ export class ConfigService extends BaseWebService implements OnDestroy {
     public set(section: string, option: string, value: any): Observable<WebReaction> {
         const valueStr: string = value;
         const currentConfig = this._config.getValue();
-        if (!currentConfig.has(section) || !currentConfig.get(section).has(option)) {
+        if (!currentConfig.has(section as keyof IConfig) ||
+            !(currentConfig.get(section as keyof IConfig) as unknown as {has: (key: string) => boolean}).has(option)) {
             return new Observable<WebReaction>(observer => {
                 observer.next(new WebReaction(false, null, `Config has no option named ${section}.${option}`));
             });


### PR DESCRIPTION
…eer-deps

- Remove core-js dependency (no longer needed with Angular 19)
- Update immutable from v3.8.2 to v4.3.0
- Add npm overrides for karma-jasmine to resolve jasmine-core peer dep conflict
- Update config.service.ts to fix TypeScript error with Immutable v4's stricter types

Resolves: https://github.com/Jules1651/seedsync/issues/46

https://claude.ai/code/session_01MXy9gAFaxYHoq6Y46v59Xn