### PR TITLE
Replace deep copy with freeze-on-add immutability pattern (Session 8)

### DIFF
--- a/src/python/controller/controller.py
+++ b/src/python/controller/controller.py
@@ -5,7 +5,6 @@ from typing import List, Callable
 from threading import Lock
 from queue import Queue
 from enum import Enum
-import copy
 
 # my libs
 from .scan import ScannerProcess, ActiveScanner, LocalScanner, RemoteScanner
@@ -297,9 +296,12 @@ class Controller:
         self.__command_queue.put(command)
 
     def __get_model_files(self) -> List[ModelFile]:
+        # Files are frozen (immutable) after being added to the model,
+        # so we can safely return direct references without deep copying.
+        # This significantly reduces memory churn on API requests.
         model_files = []
         for filename in self.__model.get_file_names():
-            model_files.append(copy.deepcopy(self.__model.get_file(filename)))
+            model_files.append(self.__model.get_file(filename))
         return model_files
 
     def __update_model(self):

--- a/src/python/model/model.py
+++ b/src/python/model/model.py
@@ -100,6 +100,8 @@ class Model:
         self.logger.debug("LftpModel: Adding file '{}'".format(file.name))
         if file.name in self.__files:
             raise ModelError("File already exists in the model")
+        # Freeze the file to make it immutable before storing
+        file.freeze()
         self.__files[file.name] = file
         # Copy-under-lock: copy listeners while holding lock, then iterate outside lock
         with self.__listeners_lock:
@@ -135,6 +137,8 @@ class Model:
             raise ModelError("File does not exist in the model")
         old_file = self.__files[file.name]
         new_file = file
+        # Freeze the new file to make it immutable before storing
+        new_file.freeze()
         self.__files[file.name] = new_file
         # Copy-under-lock: copy listeners while holding lock, then iterate outside lock
         with self.__listeners_lock:
@@ -144,7 +148,8 @@ class Model:
 
     def get_file(self, name: str) -> ModelFile:
         """
-        Returns a copy of the file of the given name
+        Returns the file of the given name.
+        The returned file is frozen (immutable) and safe to use across threads.
         :param name:
         :return:
         """


### PR DESCRIPTION
Optimize backend performance by eliminating expensive copy.deepcopy() calls on every API request. ModelFile objects now become immutable after being added to the Model, allowing safe reference sharing.

Changes:
- Add _frozen flag and freeze() method to ModelFile
- All setters check frozen flag and raise ValueError if modified after freezing
- Model.add_file() and Model.update_file() freeze files before storing
- Controller.__get_model_files() returns direct references instead of deep copies
- Update test_update_file to match new immutable pattern
- Add tests for immutability behavior

https://claude.ai/code/session_01McHMmE3SUFVtCWyDFJrcHQ