### PR TITLE
Extract ScanManager from Controller (Session 14)

### DIFF
--- a/src/python/controller/__init__.py
+++ b/src/python/controller/__init__.py
@@ -6,4 +6,5 @@ from .controller_persist import ControllerPersist
 from .model_builder import ModelBuilder
 from .auto_queue import AutoQueue, AutoQueuePersist, IAutoQueuePersistListener, AutoQueuePattern
 from .scan import IScanner, ScannerResult, ScannerProcess, ScannerError
+from .scan_manager import ScanManager
 from .memory_monitor import MemoryMonitor, MemoryStats

--- a/src/python/controller/scan_manager.py
+++ b/src/python/controller/scan_manager.py
@@ -1,0 +1,171 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import logging
+from typing import List, Optional, Tuple
+
+from common import Context, MultiprocessingLogger
+from .scan import ScannerProcess, ScannerResult, ActiveScanner, LocalScanner, RemoteScanner
+
+
+class ScanManager:
+    """
+    Manages all scanning processes (remote, local, active).
+
+    Responsible for:
+    - Creating and owning scanner instances and their processes
+    - Lifecycle management (start/stop)
+    - Collecting scan results
+    - Updating active file tracking
+    - Exception propagation
+    - Force scan triggers
+
+    Thread-safety: The scanner processes run in separate processes and communicate
+    via multiprocessing queues, which are inherently thread-safe. The ScanManager
+    methods can be called from any thread.
+    """
+
+    def __init__(self,
+                 context: Context,
+                 mp_logger: MultiprocessingLogger):
+        """
+        Create the scan manager with all scanner processes.
+
+        Args:
+            context: Application context with config
+            mp_logger: Multiprocessing logger for child processes
+        """
+        self.__context = context
+        self.logger = context.logger.getChild("ScanManager")
+
+        # Decide the password here
+        password = context.config.lftp.remote_password if not context.config.lftp.use_ssh_key else None
+
+        # Create the scanners
+        self.__active_scanner = ActiveScanner(context.config.lftp.local_path)
+        self.__local_scanner = LocalScanner(
+            local_path=context.config.lftp.local_path,
+            use_temp_file=context.config.lftp.use_temp_file
+        )
+        self.__remote_scanner = RemoteScanner(
+            remote_address=context.config.lftp.remote_address,
+            remote_username=context.config.lftp.remote_username,
+            remote_password=password,
+            remote_port=context.config.lftp.remote_port,
+            remote_path_to_scan=context.config.lftp.remote_path,
+            local_path_to_scan_script=context.args.local_path_to_scanfs,
+            remote_path_to_scan_script=context.config.lftp.remote_path_to_scan_script
+        )
+
+        # Create the scanner processes
+        self.__active_scan_process = ScannerProcess(
+            scanner=self.__active_scanner,
+            interval_in_ms=context.config.controller.interval_ms_downloading_scan,
+            verbose=False
+        )
+        self.__local_scan_process = ScannerProcess(
+            scanner=self.__local_scanner,
+            interval_in_ms=context.config.controller.interval_ms_local_scan,
+        )
+        self.__remote_scan_process = ScannerProcess(
+            scanner=self.__remote_scanner,
+            interval_in_ms=context.config.controller.interval_ms_remote_scan,
+        )
+
+        # Setup multiprocess logging
+        self.__active_scan_process.set_multiprocessing_logger(mp_logger)
+        self.__local_scan_process.set_multiprocessing_logger(mp_logger)
+        self.__remote_scan_process.set_multiprocessing_logger(mp_logger)
+
+        self.__started = False
+
+    def start(self):
+        """
+        Start all scanner processes.
+
+        Must be called after construction and before pop_latest_results().
+        """
+        self.logger.debug("Starting scanner processes")
+        self.__active_scan_process.start()
+        self.__local_scan_process.start()
+        self.__remote_scan_process.start()
+        self.__started = True
+
+    def stop(self):
+        """
+        Terminate and join all scanner processes.
+
+        Safe to call multiple times or if not started.
+        """
+        if not self.__started:
+            return
+
+        self.logger.debug("Stopping scanner processes")
+        self.__active_scan_process.terminate()
+        self.__local_scan_process.terminate()
+        self.__remote_scan_process.terminate()
+        self.__active_scan_process.join()
+        self.__local_scan_process.join()
+        self.__remote_scan_process.join()
+        self.__started = False
+        self.logger.debug("Scanner processes stopped")
+
+    def pop_latest_results(self) -> Tuple[Optional[ScannerResult], Optional[ScannerResult], Optional[ScannerResult]]:
+        """
+        Get latest results from all scanner processes.
+
+        Drains each scanner's result queue and returns the most recent result.
+        This is a non-blocking operation.
+
+        Returns:
+            Tuple of (remote_result, local_result, active_result).
+            Each element is None if no new result is available since the last call.
+        """
+        remote_result = self.__remote_scan_process.pop_latest_result()
+        local_result = self.__local_scan_process.pop_latest_result()
+        active_result = self.__active_scan_process.pop_latest_result()
+        return remote_result, local_result, active_result
+
+    def update_active_files(self, file_names: List[str]):
+        """
+        Update the list of actively downloading/extracting files.
+
+        This tells the active scanner which files to scan. The active scanner
+        only scans files in this list, which allows for more frequent scans
+        of actively changing files without scanning the entire filesystem.
+
+        Args:
+            file_names: List of file names currently active (downloading or extracting).
+        """
+        self.__active_scanner.set_active_files(file_names)
+
+    def propagate_exceptions(self):
+        """
+        Propagate any exceptions from scanner processes to the caller.
+
+        Should be called periodically to detect and re-raise any errors
+        that occurred in the scanner processes.
+
+        Raises:
+            Any exception that occurred in a scanner process.
+        """
+        self.__active_scan_process.propagate_exception()
+        self.__local_scan_process.propagate_exception()
+        self.__remote_scan_process.propagate_exception()
+
+    def force_local_scan(self):
+        """
+        Force an immediate local scan.
+
+        Use after local file operations (e.g., deletion) to quickly
+        update the model with the new filesystem state.
+        """
+        self.__local_scan_process.force_scan()
+
+    def force_remote_scan(self):
+        """
+        Force an immediate remote scan.
+
+        Use after remote file operations (e.g., deletion) to quickly
+        update the model with the new filesystem state.
+        """
+        self.__remote_scan_process.force_scan()

--- a/src/python/tests/unittests/test_controller/test_scan_manager.py
+++ b/src/python/tests/unittests/test_controller/test_scan_manager.py
@@ -1,0 +1,248 @@
+# Copyright 2017, Inderpreet Singh, All rights reserved.
+
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from controller import ScanManager
+
+
+class TestScanManager(unittest.TestCase):
+    """Unit tests for ScanManager."""
+
+    def setUp(self):
+        """Set up mocked context and mp_logger for tests."""
+        # Create mock context with required config attributes
+        self.mock_context = MagicMock()
+        self.mock_context.logger = MagicMock()
+
+        # Mock config attributes
+        self.mock_context.config.lftp.local_path = "/local/path"
+        self.mock_context.config.lftp.use_temp_file = False
+        self.mock_context.config.lftp.remote_address = "remote.server.com"
+        self.mock_context.config.lftp.remote_username = "user"
+        self.mock_context.config.lftp.remote_password = "password"
+        self.mock_context.config.lftp.use_ssh_key = False
+        self.mock_context.config.lftp.remote_port = 22
+        self.mock_context.config.lftp.remote_path = "/remote/path"
+        self.mock_context.config.lftp.remote_path_to_scan_script = "/usr/bin/scanfs"
+        self.mock_context.args.local_path_to_scanfs = "/local/bin/scanfs"
+        self.mock_context.config.controller.interval_ms_downloading_scan = 500
+        self.mock_context.config.controller.interval_ms_local_scan = 30000
+        self.mock_context.config.controller.interval_ms_remote_scan = 30000
+
+        self.mock_mp_logger = MagicMock()
+
+    @patch('controller.scan_manager.ScannerProcess')
+    @patch('controller.scan_manager.ActiveScanner')
+    @patch('controller.scan_manager.LocalScanner')
+    @patch('controller.scan_manager.RemoteScanner')
+    def test_init_creates_scanners_and_processes(
+            self, mock_remote_scanner, mock_local_scanner,
+            mock_active_scanner, mock_scanner_process):
+        """Test that __init__ creates all scanners and processes."""
+        manager = ScanManager(self.mock_context, self.mock_mp_logger)
+
+        # Verify scanners were created with correct arguments
+        mock_active_scanner.assert_called_once_with("/local/path")
+        mock_local_scanner.assert_called_once_with(
+            local_path="/local/path",
+            use_temp_file=False
+        )
+        mock_remote_scanner.assert_called_once()
+
+        # Verify scanner processes were created (3 total)
+        self.assertEqual(mock_scanner_process.call_count, 3)
+
+    @patch('controller.scan_manager.ScannerProcess')
+    @patch('controller.scan_manager.ActiveScanner')
+    @patch('controller.scan_manager.LocalScanner')
+    @patch('controller.scan_manager.RemoteScanner')
+    def test_start_starts_all_processes(
+            self, mock_remote_scanner, mock_local_scanner,
+            mock_active_scanner, mock_scanner_process):
+        """Test that start() starts all scanner processes."""
+        # Setup mock processes
+        mock_process = MagicMock()
+        mock_scanner_process.return_value = mock_process
+
+        manager = ScanManager(self.mock_context, self.mock_mp_logger)
+        manager.start()
+
+        # Verify start was called on each process (3 times)
+        self.assertEqual(mock_process.start.call_count, 3)
+
+    @patch('controller.scan_manager.ScannerProcess')
+    @patch('controller.scan_manager.ActiveScanner')
+    @patch('controller.scan_manager.LocalScanner')
+    @patch('controller.scan_manager.RemoteScanner')
+    def test_stop_terminates_and_joins_all_processes(
+            self, mock_remote_scanner, mock_local_scanner,
+            mock_active_scanner, mock_scanner_process):
+        """Test that stop() terminates and joins all scanner processes."""
+        # Setup mock processes
+        mock_process = MagicMock()
+        mock_scanner_process.return_value = mock_process
+
+        manager = ScanManager(self.mock_context, self.mock_mp_logger)
+        manager.start()
+        manager.stop()
+
+        # Verify terminate and join were called on each process (3 times each)
+        self.assertEqual(mock_process.terminate.call_count, 3)
+        self.assertEqual(mock_process.join.call_count, 3)
+
+    @patch('controller.scan_manager.ScannerProcess')
+    @patch('controller.scan_manager.ActiveScanner')
+    @patch('controller.scan_manager.LocalScanner')
+    @patch('controller.scan_manager.RemoteScanner')
+    def test_stop_without_start_is_safe(
+            self, mock_remote_scanner, mock_local_scanner,
+            mock_active_scanner, mock_scanner_process):
+        """Test that stop() without start() doesn't raise errors."""
+        mock_process = MagicMock()
+        mock_scanner_process.return_value = mock_process
+
+        manager = ScanManager(self.mock_context, self.mock_mp_logger)
+        # Should not raise
+        manager.stop()
+
+        # Verify terminate was not called
+        mock_process.terminate.assert_not_called()
+
+    @patch('controller.scan_manager.ScannerProcess')
+    @patch('controller.scan_manager.ActiveScanner')
+    @patch('controller.scan_manager.LocalScanner')
+    @patch('controller.scan_manager.RemoteScanner')
+    def test_pop_latest_results_returns_results_from_all_scanners(
+            self, mock_remote_scanner, mock_local_scanner,
+            mock_active_scanner, mock_scanner_process):
+        """Test that pop_latest_results() returns results from all scanners."""
+        # Create distinct mock processes for each scanner
+        mock_remote_process = MagicMock()
+        mock_local_process = MagicMock()
+        mock_active_process = MagicMock()
+
+        # Set up return values for pop_latest_result
+        mock_remote_result = MagicMock()
+        mock_local_result = MagicMock()
+        mock_active_result = MagicMock()
+
+        mock_remote_process.pop_latest_result.return_value = mock_remote_result
+        mock_local_process.pop_latest_result.return_value = mock_local_result
+        mock_active_process.pop_latest_result.return_value = mock_active_result
+
+        # Make ScannerProcess return different mocks for each call
+        mock_scanner_process.side_effect = [
+            mock_active_process, mock_local_process, mock_remote_process
+        ]
+
+        manager = ScanManager(self.mock_context, self.mock_mp_logger)
+        result = manager.pop_latest_results()
+
+        # Verify results are returned in correct order (remote, local, active)
+        self.assertEqual(result, (mock_remote_result, mock_local_result, mock_active_result))
+
+    @patch('controller.scan_manager.ScannerProcess')
+    @patch('controller.scan_manager.ActiveScanner')
+    @patch('controller.scan_manager.LocalScanner')
+    @patch('controller.scan_manager.RemoteScanner')
+    def test_update_active_files_delegates_to_active_scanner(
+            self, mock_remote_scanner, mock_local_scanner,
+            mock_active_scanner, mock_scanner_process):
+        """Test that update_active_files() delegates to active scanner."""
+        mock_active = MagicMock()
+        mock_active_scanner.return_value = mock_active
+
+        manager = ScanManager(self.mock_context, self.mock_mp_logger)
+
+        file_names = ["file1", "file2", "file3"]
+        manager.update_active_files(file_names)
+
+        mock_active.set_active_files.assert_called_once_with(file_names)
+
+    @patch('controller.scan_manager.ScannerProcess')
+    @patch('controller.scan_manager.ActiveScanner')
+    @patch('controller.scan_manager.LocalScanner')
+    @patch('controller.scan_manager.RemoteScanner')
+    def test_propagate_exceptions_calls_all_processes(
+            self, mock_remote_scanner, mock_local_scanner,
+            mock_active_scanner, mock_scanner_process):
+        """Test that propagate_exceptions() calls propagate_exception on all processes."""
+        mock_process = MagicMock()
+        mock_scanner_process.return_value = mock_process
+
+        manager = ScanManager(self.mock_context, self.mock_mp_logger)
+        manager.propagate_exceptions()
+
+        # Verify propagate_exception was called on each process (3 times)
+        self.assertEqual(mock_process.propagate_exception.call_count, 3)
+
+    @patch('controller.scan_manager.ScannerProcess')
+    @patch('controller.scan_manager.ActiveScanner')
+    @patch('controller.scan_manager.LocalScanner')
+    @patch('controller.scan_manager.RemoteScanner')
+    def test_force_local_scan_delegates_to_local_process(
+            self, mock_remote_scanner, mock_local_scanner,
+            mock_active_scanner, mock_scanner_process):
+        """Test that force_local_scan() calls force_scan on local process."""
+        # Create distinct mock processes
+        mock_active_process = MagicMock()
+        mock_local_process = MagicMock()
+        mock_remote_process = MagicMock()
+
+        mock_scanner_process.side_effect = [
+            mock_active_process, mock_local_process, mock_remote_process
+        ]
+
+        manager = ScanManager(self.mock_context, self.mock_mp_logger)
+        manager.force_local_scan()
+
+        # Verify force_scan was called on local process only
+        mock_local_process.force_scan.assert_called_once()
+        mock_remote_process.force_scan.assert_not_called()
+        mock_active_process.force_scan.assert_not_called()
+
+    @patch('controller.scan_manager.ScannerProcess')
+    @patch('controller.scan_manager.ActiveScanner')
+    @patch('controller.scan_manager.LocalScanner')
+    @patch('controller.scan_manager.RemoteScanner')
+    def test_force_remote_scan_delegates_to_remote_process(
+            self, mock_remote_scanner, mock_local_scanner,
+            mock_active_scanner, mock_scanner_process):
+        """Test that force_remote_scan() calls force_scan on remote process."""
+        # Create distinct mock processes
+        mock_active_process = MagicMock()
+        mock_local_process = MagicMock()
+        mock_remote_process = MagicMock()
+
+        mock_scanner_process.side_effect = [
+            mock_active_process, mock_local_process, mock_remote_process
+        ]
+
+        manager = ScanManager(self.mock_context, self.mock_mp_logger)
+        manager.force_remote_scan()
+
+        # Verify force_scan was called on remote process only
+        mock_remote_process.force_scan.assert_called_once()
+        mock_local_process.force_scan.assert_not_called()
+        mock_active_process.force_scan.assert_not_called()
+
+    @patch('controller.scan_manager.ScannerProcess')
+    @patch('controller.scan_manager.ActiveScanner')
+    @patch('controller.scan_manager.LocalScanner')
+    @patch('controller.scan_manager.RemoteScanner')
+    def test_ssh_key_mode_uses_none_password(
+            self, mock_remote_scanner, mock_local_scanner,
+            mock_active_scanner, mock_scanner_process):
+        """Test that SSH key mode uses None for password."""
+        self.mock_context.config.lftp.use_ssh_key = True
+
+        manager = ScanManager(self.mock_context, self.mock_mp_logger)
+
+        # Verify remote scanner was called with password=None
+        call_kwargs = mock_remote_scanner.call_args.kwargs
+        self.assertIsNone(call_kwargs['remote_password'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit extracts scanner functionality into a new ScanManager class, reducing Controller's responsibilities and improving code organization.

Changes:
- Create src/python/controller/scan_manager.py with ScanManager class
- Move scanner creation/lifecycle from Controller to ScanManager
- Update Controller to delegate scan operations to ScanManager
- Add 10 unit tests for ScanManager in test_scan_manager.py
- Export ScanManager from controller module __init__.py

ScanManager handles:
- All scanner instances (ActiveScanner, LocalScanner, RemoteScanner)
- Scanner process lifecycle (start/stop)
- Result collection (pop_latest_results)
- Active file tracking (update_active_files)
- Exception propagation
- Force scan triggers (force_local_scan, force_remote_scan)

Controller changes:
- Replaced 6 scanner-related fields with single __scan_manager field
- Moved MultiprocessingLogger creation earlier in __init__
- Updated all scan-related code to delegate to ScanManager

287 tests pass (277 original + 10 new ScanManager tests).

https://claude.ai/code/session_01HG7czvNStS9wJgB9WwcvYe