### PR TITLE
Fix SSH password test failure on OpenSSH 9.x

### DIFF
--- a/src/docker/test/python/Dockerfile
+++ b/src/docker/test/python/Dockerfile
@@ -18,6 +18,11 @@ RUN ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa && \
     cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
 # Disable the known hosts prompt
 RUN echo "StrictHostKeyChecking no\nUserKnownHostsFile /dev/null\nLogLevel=quiet" > /root/.ssh/config
+# Enable password authentication in sshd (required for OpenSSH 9.x in Debian Bookworm)
+# Also enable keyboard-interactive for compatibility
+RUN echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config && \
+    echo "KbdInteractiveAuthentication yes" >> /etc/ssh/sshd_config && \
+    echo "UsePAM yes" >> /etc/ssh/sshd_config
 
 # create the seedsynctest user, add root's public key to seedsynctest
 RUN useradd --create-home -s /bin/bash seedsynctest && \


### PR DESCRIPTION
Debian Bookworm (the base for python:3.11-slim) uses OpenSSH 9.x which has stricter default authentication settings. The test container now explicitly enables password authentication in sshd_config so the test_copy_error_bad_password test can work correctly.

https://claude.ai/code/session_014yz7BB2DGzi2Tyh6LSpVeP