### PR TITLE
Persist dashboard status filter selection to localStorage

### DIFF
--- a/src/angular/src/app/common/storage-keys.ts
+++ b/src/angular/src/app/common/storage-keys.ts
@@ -2,4 +2,5 @@ export class StorageKeys {
     public static readonly VIEW_OPTION_SHOW_DETAILS = "view-option-show-details";
     public static readonly VIEW_OPTION_SORT_METHOD = "view-option-sort-method";
     public static readonly VIEW_OPTION_PIN = "view-option-pin";
+    public static readonly VIEW_OPTION_DEFAULT_STATUS_FILTER = "view-option-default-status-filter";
 }

--- a/src/angular/src/app/services/files/view-file-options.service.ts
+++ b/src/angular/src/app/services/files/view-file-options.service.ts
@@ -30,12 +30,14 @@ export class ViewFileOptionsService {
                 ViewFileOptions.SortMethod.STATUS;
         const pinFilter: boolean =
             this._storage.get(StorageKeys.VIEW_OPTION_PIN) || false;
+        const defaultStatusFilter: ViewFile.Status =
+            this._storage.get(StorageKeys.VIEW_OPTION_DEFAULT_STATUS_FILTER) || null;
 
         this._options = new BehaviorSubject(
             new ViewFileOptions({
                 showDetails: showDetails,
                 sortMethod: sortMethod,
-                selectedStatusFilter: null,
+                selectedStatusFilter: defaultStatusFilter,
                 nameFilter: null,
                 pinFilter: pinFilter,
             })
@@ -71,6 +73,7 @@ export class ViewFileOptionsService {
         if (options.selectedStatusFilter !== status) {
             const newOptions = new ViewFileOptions(options.set("selectedStatusFilter", status));
             this._options.next(newOptions);
+            this._storage.set(StorageKeys.VIEW_OPTION_DEFAULT_STATUS_FILTER, status);
             this._logger.debug("ViewOption selectedStatusFilter set to: " + newOptions.selectedStatusFilter);
         }
     }


### PR DESCRIPTION
The selected status filter is now saved and restored on page reload, allowing users to set their preferred default filter for the dashboard.

https://claude.ai/code/session_01JEKGW1uE7rPYfYE13HR2YS

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [ ] Python unit tests (`make run-tests-python`)
- [ ] Angular unit tests (`make run-tests-angular`)
- [ ] E2E tests (`make run-tests-e2e`)
- [ ] Manual testing

## Checklist

- [ ] My code follows the project's coding guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally
- [ ] I have updated documentation if needed

## Screenshots (if applicable)

Add screenshots for UI changes.
