### PR TITLE
Fix logs page hang caused by unsafe lock management

### DIFF
--- a/src/python/common/status.py
+++ b/src/python/common/status.py
@@ -162,16 +162,14 @@ class Status(BaseStatus):
         return copy
 
     def add_listener(self, listener: IStatusListener):
-        self._listeners_lock.acquire()
-        if listener not in self._listeners:
-            self._listeners.append(listener)
-        self._listeners_lock.release()
+        with self._listeners_lock:
+            if listener not in self._listeners:
+                self._listeners.append(listener)
 
     def remove_listener(self, listener: IStatusListener):
-        self._listeners_lock.acquire()
-        if listener in self._listeners:
-            self._listeners.remove(listener)
-        self._listeners_lock.release()
+        with self._listeners_lock:
+            if listener in self._listeners:
+                self._listeners.remove(listener)
 
     def __create_component(self, comp_cls: Type[T]) -> T:
         """Create a component and register our listener with it"""


### PR DESCRIPTION
Replace manual acquire()/release() with context managers (with statements) in CachedQueueLogHandler and Status classes. If an exception occurred between acquire and release, the lock would never be released, causing permanent deadlocks when accessing the logs page SSE stream.

https://claude.ai/code/session_018Kjj2NJSzPRfjXgXmBxHUP

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [ ] Python unit tests (`make run-tests-python`)
- [ ] Angular unit tests (`make run-tests-angular`)
- [ ] E2E tests (`make run-tests-e2e`)
- [ ] Manual testing

## Checklist

- [ ] My code follows the project's coding guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally
- [ ] I have updated documentation if needed

## Screenshots (if applicable)

Add screenshots for UI changes.
