### PR TITLE
Add status indicator to logs page when no logs displayed

### DIFF
--- a/src/angular/src/app/pages/logs/logs-page.component.html
+++ b/src/angular/src/app/pages/logs/logs-page.component.html
@@ -17,6 +17,12 @@
         </p>
     </ng-template>
 
+    <!-- Status message when not connected or waiting for logs -->
+    <div class="status-message" *ngIf="!hasReceivedLogs">
+        <span *ngIf="!isConnected">{{Localization.Notification.STATUS_CONNECTION_WAITING}}</span>
+        <span *ngIf="isConnected">Connected - waiting for logs...</span>
+    </div>
+
     <button id="btn-scroll-top"
             type="button"
             class="btn btn-primary btn-scroll"

--- a/src/angular/src/app/pages/logs/logs-page.component.scss
+++ b/src/angular/src/app/pages/logs/logs-page.component.scss
@@ -9,6 +9,13 @@
     flex-direction: column;
     justify-content: center;
 
+    .status-message {
+        padding: 20px;
+        text-align: center;
+        color: #666;
+        font-size: 14px;
+    }
+
     .log-marker {
         width: 100%;
         height: 2px;


### PR DESCRIPTION
The logs page was showing a completely blank/white page when no logs had been received yet. This was confusing because there was no visual feedback about the connection state.

Added:
- Connection status tracking via ConnectedService
- Status message showing "Waiting for SeedSync service to respond..." when disconnected
- Status message showing "Connected - waiting for logs..." when connected but no logs received yet
- The status message is hidden once the first log appears

https://claude.ai/code/session_01SRPrmnHtMrcNPi1WSYTcAe

## Description

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [ ] Python unit tests (`make run-tests-python`)
- [ ] Angular unit tests (`make run-tests-angular`)
- [ ] E2E tests (`make run-tests-e2e`)
- [ ] Manual testing

## Checklist

- [ ] My code follows the project's coding guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally
- [ ] I have updated documentation if needed

## Screenshots (if applicable)

Add screenshots for UI changes.
